### PR TITLE
This fixes the exception handling.

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -11,5 +11,5 @@ def file_type(key):
     file_extension = file_info[1]
     try:
         return mimetypes.types_map[file_extension]
-    except KeyError():
+    except KeyError:
         return 'Unknown'


### PR DESCRIPTION
I think this is Python 2 style of exception handling:
```
mydict = {'a': 1, 'b': 2}
try:
    print(mydict['z'])
except KeyError():
    print("oops")
```

and python 3 drops the parentheses:

```
except KeyError:
```


